### PR TITLE
force update while testing async api calls via nock library

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,8 @@ export const createWaitForElement = (selector, maxTime = 2000, interval = 10) =>
         return reject(new AssertionError(`Expected to find ${selector} within ${maxTime}ms, but it was never found.`))
       }
 
+      rootComponent.update();
+
       const targetComponent = rootComponent.find(selector);
       if (targetComponent.length) {
         clearInterval(intervalId);


### PR DESCRIPTION
We encountered problems while waiting for result of async api call. Problem was, that enzyme couldn't find desired element in wait loop. So this code inside setInterval function
```
console.log(rootComponent.html());
// rootComponent.update();
const targetComponent = rootComponent.find(selector);
console.log(selector)
console.log(targetComponent);
```
outputs this
```<h1 class="article-title"></h1>
.qa__title
ReactWrapper { length: 0 }
<h1 class="article-title"></h1>
.qa__title
ReactWrapper { length: 0 }
<h1 class="article-title"></h1>
.qa__title
ReactWrapper { length: 0 }
<h1 class="article-title"><span class="qa__title"></span></h1>
.qa__title
ReactWrapper { length: 0 }
<h1 class="article-title"><span class="qa__title"></span></h1>
.qa__title
ReactWrapper { length: 0 }```

notice the empty result, even though the element is already rendered in component.

This is how we solved it - there are no tests for it though, since all current tests mock enzyme out..
